### PR TITLE
Remove redundant peerDependencies

### DIFF
--- a/packages/cdk-codepipeline-slack/package.json
+++ b/packages/cdk-codepipeline-slack/package.json
@@ -29,9 +29,6 @@
     "build": "cdkdx build",
     "test": "cdkdx test"
   },
-  "peerDependencies": {
-    "@aws-cdk/core": "1.31.0"
-  },
   "dependencies": {
     "@aws-cdk/aws-apigateway": "^1.44.0",
     "@aws-cdk/aws-codebuild": "^1.44.0",


### PR DESCRIPTION
`@aws-cdk/core` was listed in `peerDependenices` with a mismatching value, and also listed in `dependencies`