### PR TITLE
cdk-cloudfront-authorization: Skip basic auth if client secret is undefined

### DIFF
--- a/packages/cdk-cloudfront-authorization/src/lambdas/refresh-auth/index.ts
+++ b/packages/cdk-cloudfront-authorization/src/lambdas/refresh-auth/index.ts
@@ -29,7 +29,7 @@ export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFront
       'Content-Type': 'application/x-www-form-urlencoded',
     };
 
-    if (CONFIG.clientSecret !== '' && CONFIG.clientSecret !== undefined) {
+    if (CONFIG.clientSecret) {
       const encodedSecret = Buffer.from(`${CONFIG.clientId}:${CONFIG.clientSecret}`).toString('base64');
       headers['Authorization'] = `Basic ${encodedSecret}`;
     }

--- a/packages/cdk-cloudfront-authorization/src/lambdas/refresh-auth/index.ts
+++ b/packages/cdk-cloudfront-authorization/src/lambdas/refresh-auth/index.ts
@@ -29,7 +29,7 @@ export const handler = async (event: CloudFrontRequestEvent): Promise<CloudFront
       'Content-Type': 'application/x-www-form-urlencoded',
     };
 
-    if (CONFIG.clientSecret !== '') {
+    if (CONFIG.clientSecret !== '' && CONFIG.clientSecret !== undefined) {
       const encodedSecret = Buffer.from(`${CONFIG.clientId}:${CONFIG.clientSecret}`).toString('base64');
       headers['Authorization'] = `Basic ${encodedSecret}`;
     }


### PR DESCRIPTION
Hi,

Thank you for providing this library.

I used the package cdk-cloudfront-authorization.
When the authentication token was expired, the refresh auth action wasn't successfull. The error _invalid_client_ occurred.

My cognito app client doesn't use client secrets. However, an authorization header was sent to cognito.
The authorization header contained `1234567890:undefined`. Therefore, I've implemented an additional check to skip the authorization header if the value is undefined.

Best regards,
Julian