### PR TITLE
fix: Enable route53 cloudfront target

### DIFF
--- a/packages/cdk-cloudfront-authorization/API.md
+++ b/packages/cdk-cloudfront-authorization/API.md
@@ -284,7 +284,7 @@ __Returns__:
 
 
 
-__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable)
+__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable), [IDistribution](#aws-cdk-aws-cloudfront-idistribution), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable), [IConstruct](#aws-cdk-core-iconstruct), [IResource](#aws-cdk-core-iresource)
 __Extends__: [Construct](#aws-cdk-core-construct)
 
 ### Initializer
@@ -318,6 +318,18 @@ new BaseDistribution(scope: Construct, id: string, props: BaseDistributionProps)
   * **authorization** (<code>[IAuthorization](#cloudcomponents-cdk-cloudfront-authorization-iauthorization)</code>)  *No description* 
   * **errorResponses** (<code>Array<[ErrorResponse](#aws-cdk-aws-cloudfront-errorresponse)></code>)  *No description* __*Optional*__
 
+
+
+### Properties
+
+
+Name | Type | Description 
+-----|------|-------------
+**distributionDomainName** | <code>string</code> | The domain name of the Distribution, such as d111111abcdef8.cloudfront.net.
+**distributionId** | <code>string</code> | The distribution ID for this distribution.
+**domainName** | <code>string</code> | (deprecated) The domain name of the Distribution, such as d111111abcdef8.cloudfront.net.
+**env** | <code>[ResourceEnvironment](#aws-cdk-core-resourceenvironment)</code> | The environment this resource belongs to.
+**stack** | <code>[Stack](#aws-cdk-core-stack)</code> | The stack in which this resource is defined.
 
 ### Methods
 
@@ -489,7 +501,7 @@ __Returns__:
 
 
 
-__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable)
+__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable), [IDistribution](#aws-cdk-aws-cloudfront-idistribution), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable), [IConstruct](#aws-cdk-core-iconstruct), [IResource](#aws-cdk-core-iresource)
 __Extends__: [BaseDistribution](#cloudcomponents-cdk-cloudfront-authorization-basedistribution)
 
 ### Initializer
@@ -597,7 +609,7 @@ __Returns__:
 
 
 
-__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable)
+__Implements__: [IConstruct](#constructs-iconstruct), [IConstruct](#aws-cdk-core-iconstruct), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable), [IDistribution](#aws-cdk-aws-cloudfront-idistribution), [IConstruct](#constructs-iconstruct), [IDependable](#aws-cdk-core-idependable), [IConstruct](#aws-cdk-core-iconstruct), [IResource](#aws-cdk-core-iresource)
 __Extends__: [BaseDistribution](#cloudcomponents-cdk-cloudfront-authorization-basedistribution)
 
 ### Initializer

--- a/packages/cdk-cloudfront-authorization/package.json
+++ b/packages/cdk-cloudfront-authorization/package.json
@@ -66,8 +66,8 @@
     "@aws-cdk/aws-s3": "^1.79.0",
     "@aws-cdk/core": "^1.79.0",
     "@aws-cdk/custom-resources": "^1.79.0",
-    "@cloudcomponents/cdk-deletable-bucket": "^1.14.0",
-    "@cloudcomponents/cdk-lambda-at-edge-pattern": "^1.14.0",
+    "@cloudcomponents/cdk-deletable-bucket": "^1.14.1",
+    "@cloudcomponents/cdk-lambda-at-edge-pattern": "^1.14.1",
     "constructs": "^3.2.0"
   },
   "dependencies": {

--- a/packages/cdk-developer-tools-notifications/package.json
+++ b/packages/cdk-developer-tools-notifications/package.json
@@ -73,7 +73,7 @@
     "@aws-cdk/aws-lambda-event-sources": "^1.79.0",
     "@aws-cdk/aws-sns": "^1.79.0",
     "@aws-cdk/core": "^1.79.0",
-    "@cloudcomponents/cdk-chatops": "^1.14.0",
+    "@cloudcomponents/cdk-chatops": "^1.14.1",
     "constructs": "^3.2.0"
   },
   "dependencies": {

--- a/packages/cdk-static-website/package.json
+++ b/packages/cdk-static-website/package.json
@@ -69,7 +69,7 @@
     "@aws-cdk/aws-s3": "^1.79.0",
     "@aws-cdk/aws-s3-deployment": "^1.79.0",
     "@aws-cdk/core": "^1.79.0",
-    "@cloudcomponents/cdk-deletable-bucket": "^1.14.0",
+    "@cloudcomponents/cdk-deletable-bucket": "^1.14.1",
     "constructs": "^3.2.0"
   },
   "dependencies": {


### PR DESCRIPTION
fixes: #64

After the fix, you can use the distribution as route53 cloudfront target:
```typescript
//...
const authorization = new SpaAuthorization(this, 'Authorization', {
      userPool,
    });

const distribution = new SpaDistribution(this, 'Distribution', {
      authorization,
//...
    });

new route53.ARecord(this, 'CloudfrontAlias', {
      zone: externalHostedZone,
      target: route53.RecordTarget.fromAlias(new targets.CloudFrontTarget(distribution)),
      recordName: '<record name>'
    });

//...
```