### PR TITLE
ISSUE-67 - Use the containerPort parameter that is passed into DummyT…

### DIFF
--- a/packages/cdk-blue-green-container-deployment/src/dummy-task-definition.ts
+++ b/packages/cdk-blue-green-container-deployment/src/dummy-task-definition.ts
@@ -26,6 +26,8 @@ export class DummyTaskDefinition extends Construct implements IDummyTaskDefiniti
 
   public readonly taskDefinitionArn: string;
 
+  public readonly containerPort: number;
+
   constructor(scope: Construct, id: string, props: DummyTaskDefinitionProps) {
     super(scope, id);
 
@@ -52,6 +54,7 @@ export class DummyTaskDefinition extends Construct implements IDummyTaskDefiniti
     });
 
     this.family = props.family || this.node.uniqueId;
+    this.containerPort = props.containerPort || 80;
 
     const taskDefinition = new CustomResource(this, 'CustomResource', {
       serviceToken,
@@ -61,6 +64,7 @@ export class DummyTaskDefinition extends Construct implements IDummyTaskDefiniti
         Image: props.image,
         ExecutionRoleArn: this.executionRole.roleArn,
         NetworkMode: NetworkMode.AWS_VPC,
+        ContainerPort: this.containerPort,
       },
     });
 

--- a/packages/cdk-blue-green-container-deployment/src/lambdas/dummy-task-definition/index.ts
+++ b/packages/cdk-blue-green-container-deployment/src/lambdas/dummy-task-definition/index.ts
@@ -10,6 +10,7 @@ export interface EcsTaskDefinitionProps {
   image: string;
   executionRoleArn: string;
   networkMode: string;
+  containerPort: number;
 }
 
 const ecs = new ECS();
@@ -19,10 +20,11 @@ const getProperties = (props: CloudFormationCustomResourceEvent['ResourcePropert
   image: props.Image as string,
   executionRoleArn: props.ExecutionRoleArn as string,
   networkMode: props.NetworkMode as string,
+  containerPort: props.ContainerPort as number,
 });
 
 const onCreate = async (event: CloudFormationCustomResourceCreateEvent): Promise<HandlerReturn> => {
-  const { family, image, executionRoleArn, networkMode } = getProperties(event.ResourceProperties);
+  const { family, image, executionRoleArn, networkMode, containerPort } = getProperties(event.ResourceProperties);
 
   const { taskDefinition } = await ecs
     .registerTaskDefinition({
@@ -38,9 +40,9 @@ const onCreate = async (event: CloudFormationCustomResourceCreateEvent): Promise
           image,
           portMappings: [
             {
-              hostPort: 80,
+              hostPort: containerPort,
               protocol: 'tcp',
-              containerPort: 80,
+              containerPort: containerPort,
             },
           ],
         },


### PR DESCRIPTION
This is to fix issue 67.

The container port for the DummyTaskDefinition always used port 80. It now uses the container port that is passed in when initializing DummyTaskDefinition. 

closes #67 