### PR TITLE
Pin CDK version when upgrading

### DIFF
--- a/packages/cdk-cloudfront-authorization/package.json
+++ b/packages/cdk-cloudfront-authorization/package.json
@@ -33,7 +33,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-codecommit-backup/package.json
+++ b/packages/cdk-codecommit-backup/package.json
@@ -37,7 +37,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-codepipeline-anchore-inline-scan-action/package.json
+++ b/packages/cdk-codepipeline-anchore-inline-scan-action/package.json
@@ -37,7 +37,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-codepipeline-check-parameter-action/package.json
+++ b/packages/cdk-codepipeline-check-parameter-action/package.json
@@ -35,7 +35,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-codepipeline-dockerfile-linter-action/package.json
+++ b/packages/cdk-codepipeline-dockerfile-linter-action/package.json
@@ -37,7 +37,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-codepipeline-merge-action/package.json
+++ b/packages/cdk-codepipeline-merge-action/package.json
@@ -36,7 +36,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-codepipeline-slack/package.json
+++ b/packages/cdk-codepipeline-slack/package.json
@@ -39,7 +39,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-container-registry/package.json
+++ b/packages/cdk-container-registry/package.json
@@ -35,7 +35,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-contentful-webhook/package.json
+++ b/packages/cdk-contentful-webhook/package.json
@@ -34,7 +34,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-deletable-bucket/package.json
+++ b/packages/cdk-deletable-bucket/package.json
@@ -34,7 +34,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-dependency-check/package.json
+++ b/packages/cdk-dependency-check/package.json
@@ -35,7 +35,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-developer-tools-notifications/package.json
+++ b/packages/cdk-developer-tools-notifications/package.json
@@ -39,7 +39,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-dynamodb-seeder/package.json
+++ b/packages/cdk-dynamodb-seeder/package.json
@@ -34,7 +34,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-github-webhook/package.json
+++ b/packages/cdk-github-webhook/package.json
@@ -34,7 +34,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-lambda-at-edge-pattern/package.json
+++ b/packages/cdk-lambda-at-edge-pattern/package.json
@@ -35,7 +35,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-pull-request-approval-rule/package.json
+++ b/packages/cdk-pull-request-approval-rule/package.json
@@ -37,7 +37,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-pull-request-check/package.json
+++ b/packages/cdk-pull-request-check/package.json
@@ -35,7 +35,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-static-website/package.json
+++ b/packages/cdk-static-website/package.json
@@ -38,7 +38,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-stripe-webhook/package.json
+++ b/packages/cdk-stripe-webhook/package.json
@@ -34,7 +34,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",

--- a/packages/cdk-temp-stack/package.json
+++ b/packages/cdk-temp-stack/package.json
@@ -35,7 +35,7 @@
     "watch": "cdkdx build -w",
     "test": "cdkdx test",
     "lint": "cdkdx lint",
-    "upgrade:cdk": "cdkdx upgrade-cdk",
+    "upgrade:cdk": "cdkdx upgrade-cdk --mode=pinned",
     "package": "cdkdx package",
     "docgen": "cdkdx docgen",
     "release:npm": "cdkdx release npm",


### PR DESCRIPTION
When running `cdkdx upgrade-cdk`, ensure that the cdk version is pinned rather than flexible. 

Fixes #75 