### PR TITLE
expose the StaticWebsite distribution

### DIFF
--- a/packages/cdk-static-website/src/static-website.ts
+++ b/packages/cdk-static-website/src/static-website.ts
@@ -71,7 +71,7 @@ export interface StaticWebsiteProps extends WebsiteBucketProps {
 }
 
 export class StaticWebsite extends Construct {
-  private readonly distribution: CloudFrontWebDistribution;
+  readonly distribution: CloudFrontWebDistribution;
 
   constructor(scope: Construct, id: string, props: StaticWebsiteProps = {}) {
     super(scope, id);


### PR DESCRIPTION
I want to be able to issue an invalidation after cdk finishes but I need to be able to output the distribution id. #57 explains how to add an output, but without access to the underlying distribution you can't output it. 