### PR TITLE
added new props to PullRequestCheck to be passed to aws-codebuild.Pro…

### DIFF
--- a/packages/cdk-pull-request-check/package.json
+++ b/packages/cdk-pull-request-check/package.json
@@ -61,6 +61,7 @@
   "peerDependencies": {
     "@aws-cdk/aws-codebuild": "^1.93.0",
     "@aws-cdk/aws-codecommit": "^1.93.0",
+    "@aws-cdk/aws-ec2": "^1.93.0",
     "@aws-cdk/aws-events": "^1.93.0",
     "@aws-cdk/aws-events-targets": "^1.93.0",
     "@aws-cdk/aws-iam": "^1.93.0",
@@ -71,6 +72,7 @@
   "dependencies": {
     "@aws-cdk/aws-codebuild": "^1.93.0",
     "@aws-cdk/aws-codecommit": "^1.93.0",
+    "@aws-cdk/aws-ec2": "^1.93.0",
     "@aws-cdk/aws-events": "^1.93.0",
     "@aws-cdk/aws-events-targets": "^1.93.0",
     "@aws-cdk/aws-iam": "^1.93.0",

--- a/packages/cdk-pull-request-check/src/pull-request-check.ts
+++ b/packages/cdk-pull-request-check/src/pull-request-check.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import { BuildSpec, ComputeType, IBuildImage, LinuxBuildImage, Project, Source } from '@aws-cdk/aws-codebuild';
 import { IRepository } from '@aws-cdk/aws-codecommit';
+import { IVpc, SubnetSelection, ISecurityGroup } from '@aws-cdk/aws-ec2';
 import { EventField, RuleTargetInput, OnEventOptions, Rule } from '@aws-cdk/aws-events';
 import { CodeBuildProject, LambdaFunction } from '@aws-cdk/aws-events-targets';
 import { PolicyStatement, Effect, IRole } from '@aws-cdk/aws-iam';
@@ -68,6 +69,39 @@ export interface PullRequestCheckProps {
 
   /** The IAM service Role of the Project. */
   readonly role?: IRole;
+
+  /**
+   * VPC network to place codebuild network interfaces.
+   * Specify this if the codebuild project needs to access resources in a VPC.
+   * 
+   * @default No VPC is specified
+   */
+  readonly vpc?: IVpc;
+
+  /**
+   * Where to place the network interfaces within the VPC.
+   * Only used if 'vpc' is supplied.
+   * 
+   * @default All private subnets
+   */
+  readonly subnetSelection?: SubnetSelection;
+
+  /**
+   * What security group to associate with the codebuild project's network interfaces.
+   * If no security group is identified, one will be created automatically.
+   * Only used if 'vpc' is supplied.
+   * 
+   * @default Security group will be automatically created
+   */
+  readonly securityGroups?: ISecurityGroup[];
+  /**
+   * Whether to allow the CodeBuild to send all network traffic.
+   * If set to false, you must individually add traffic rules to allow the CodeBuild project to connect to network targets.
+   * Only used if 'vpc' is supplied.
+   * 
+   * @default true
+   */
+  readonly allowAllOutbound?: boolean;
 }
 
 /**
@@ -89,6 +123,10 @@ export class PullRequestCheck extends Construct {
       postComment = true,
       projectName = `${repository.repositoryName}-pull-request`,
       role,
+      vpc,
+      subnetSelection,
+      securityGroups,
+      allowAllOutbound,
     } = props;
 
     this.pullRequestProject = new Project(this, 'PullRequestProject', {
@@ -103,6 +141,10 @@ export class PullRequestCheck extends Construct {
       },
       buildSpec,
       role,
+      vpc: vpc,
+      subnetSelection: subnetSelection,
+      securityGroups: securityGroups,
+      allowAllOutbound: allowAllOutbound,
     });
 
     if (updateApprovalState || postComment) {

--- a/packages/cdk-pull-request-check/src/pull-request-check.ts
+++ b/packages/cdk-pull-request-check/src/pull-request-check.ts
@@ -73,7 +73,7 @@ export interface PullRequestCheckProps {
   /**
    * VPC network to place codebuild network interfaces.
    * Specify this if the codebuild project needs to access resources in a VPC.
-   * 
+   *
    * @default No VPC is specified
    */
   readonly vpc?: IVpc;
@@ -81,7 +81,7 @@ export interface PullRequestCheckProps {
   /**
    * Where to place the network interfaces within the VPC.
    * Only used if 'vpc' is supplied.
-   * 
+   *
    * @default All private subnets
    */
   readonly subnetSelection?: SubnetSelection;
@@ -90,7 +90,7 @@ export interface PullRequestCheckProps {
    * What security group to associate with the codebuild project's network interfaces.
    * If no security group is identified, one will be created automatically.
    * Only used if 'vpc' is supplied.
-   * 
+   *
    * @default Security group will be automatically created
    */
   readonly securityGroups?: ISecurityGroup[];
@@ -98,7 +98,7 @@ export interface PullRequestCheckProps {
    * Whether to allow the CodeBuild to send all network traffic.
    * If set to false, you must individually add traffic rules to allow the CodeBuild project to connect to network targets.
    * Only used if 'vpc' is supplied.
-   * 
+   *
    * @default true
    */
   readonly allowAllOutbound?: boolean;


### PR DESCRIPTION
**Disclaimer:** I don't have a ton of JS/TS experience, so I hope this is helpful, but I'm 100% open to constructive criticism. Also I haven't run this, because to be honest I wasn't really sure where to start. I also didn't add any tests because that was a little out of my depth as well.

# Purpose
I was implementing the `PullRequestCheck` package in my project and realized that it would only work if I'm able to run the CodeBuild project in a VPC (because the actions that I'm taking in the BuildSpec utilize APIs that can only be called from a VPC).

# What I've Done
I've added the following props to `PullRequestCheck`: `vpc`, `subnetSelection`, `securityGroups`, and `allowAllOutbound`. Each of those are passed to pullRequestProject. I reference documentation for [Project](https://docs.aws.amazon.com/cdk/api/latest/typescript/api/aws-codebuild/project.html#aws_codebuild_Project) and [CommonProjectProps](https://docs.aws.amazon.com/cdk/api/latest/typescript/api/aws-codebuild/commonprojectprops.html#aws_codebuild_CommonProjectProps). One thing I wasn't sure about was, the comments/documentation for `PullRequestCheckProps` I added the `@default` that would be inherited from `aws-codebuild.Project` but I didn't actually declare any defaults.

