### PR TITLE
Ability to use the Pull Request Check Function/Role as part of Approval Pool Members.

### DIFF
--- a/packages/cdk-pull-request-check/src/pull-request-check.ts
+++ b/packages/cdk-pull-request-check/src/pull-request-check.ts
@@ -125,6 +125,7 @@ export interface PullRequestCheckProps {
  */
 export class PullRequestCheck extends Construct {
   private pullRequestProject: Project;
+  public codeBuildResultFunction: Function;
 
   public constructor(scope: Construct, id: string, props: PullRequestCheckProps) {
     super(scope, id);
@@ -168,7 +169,7 @@ export class PullRequestCheck extends Construct {
     });
 
     if (updateApprovalState || postComment) {
-      const codeBuildResultFunction = new Function(this, 'CodeBuildResultFunction', {
+      this.codeBuildResultFunction = new Function(this, 'CodeBuildResultFunction', {
         runtime: Runtime.NODEJS_12_X,
         code: Code.fromAsset(path.join(__dirname, 'lambdas', 'code-build-result')),
         handler: 'index.handler',
@@ -178,7 +179,7 @@ export class PullRequestCheck extends Construct {
         },
       });
 
-      codeBuildResultFunction.addToRolePolicy(
+      this.codeBuildResultFunction.addToRolePolicy(
         new PolicyStatement({
           effect: Effect.ALLOW,
           resources: [repository.repositoryArn],
@@ -187,7 +188,7 @@ export class PullRequestCheck extends Construct {
       );
 
       this.pullRequestProject.onStateChange('PullRequestValidationRule', {
-        target: new LambdaFunction(codeBuildResultFunction),
+        target: new LambdaFunction(this.codeBuildResultFunction),
       });
     }
 


### PR DESCRIPTION
When combining `pull-request-check` and `pull-request-approval-rule` packages, it is not currently possible to require that the approval is made by the actual Pull Request Check. We need to populate the `approvalPoolMembers` property.
In my experience, I found when Pull Request Check approves a Pull Request, it does so by with the IAM role syntax `{roleArn}/{lambdaArn}`.

So concretely one would put this
```
template: {
   approvers: {
      numberOfApprovalsNeeded: 1,
      approvalPoolMembers: ["CodeBuildResultFunct-8RGRK7JL2MC7/CodeBuildResultFunct-G61QZIY7XP0F"],
   },
},
```

If list of approval pool members is empty, then any type of approval, will satisfy the approval rule, which might not be desired.

Hardcoding the resource names in `approvalPoolMembers` are obviously not good, so therefor I changed PullRequestCheck to expose the underlying Lambda function. After this change, one can do:


```
template: {
   approvers: {
      numberOfApprovalsNeeded: 1,
      approvalPoolMembers: [ prCheck.codeBuildResultFunction.role.roleArn + "/" + prCheck.codeBuildResultFunction..functionArn ],
   },
},
```

