### PR TITLE
Migrate pull requests

### DIFF
--- a/examples/pull-request-example/package.json
+++ b/examples/pull-request-example/package.json
@@ -9,9 +9,8 @@
     "cdk": "cdk"
   },
   "dependencies": {
-    "@aws-cdk/aws-codebuild": "^1.140.0",
-    "@aws-cdk/aws-codecommit": "^1.140.0",
-    "@aws-cdk/core": "^1.140.0",
+    "aws-cdk-lib": "^2.8.0",
+    "constructs": "^10.0.41",
     "@cloudcomponents/cdk-pull-request-approval-rule": "^1.49.0",
     "@cloudcomponents/cdk-pull-request-check": "^1.50.0",
     "source-map-support": "^0.5.21"

--- a/examples/pull-request-example/src/pull-request-app.ts
+++ b/examples/pull-request-example/src/pull-request-app.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import 'source-map-support/register';
-import { App } from '@aws-cdk/core';
+import { App } from 'aws-cdk-lib';
 
 import { PullRequestStack } from './pull-request-stack';
 

--- a/examples/pull-request-example/src/pull-request-stack.ts
+++ b/examples/pull-request-example/src/pull-request-stack.ts
@@ -1,8 +1,9 @@
-import { BuildSpec } from '@aws-cdk/aws-codebuild';
-import { Repository } from '@aws-cdk/aws-codecommit';
-import { Construct, Stack, StackProps } from '@aws-cdk/core';
 import { ApprovalRuleTemplate, ApprovalRuleTemplateRepositoryAssociation } from '@cloudcomponents/cdk-pull-request-approval-rule';
 import { PullRequestCheck } from '@cloudcomponents/cdk-pull-request-check';
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { BuildSpec } from 'aws-cdk-lib/aws-codebuild';
+import { Repository } from 'aws-cdk-lib/aws-codecommit';
+import { Construct } from 'constructs';
 
 export class PullRequestStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {

--- a/packages/cdk-pull-request-approval-rule/API.md
+++ b/packages/cdk-pull-request-approval-rule/API.md
@@ -43,13 +43,7 @@
 
 ### Methods
 
-- [onPrepare](#onprepare)
-- [onSynthesize](#onsynthesize)
-- [onValidate](#onvalidate)
-- [prepare](#prepare)
-- [synthesize](#synthesize)
 - [toString](#tostring)
-- [validate](#validate)
 - [isConstruct](#isconstruct)
 
 ## Constructors
@@ -80,9 +74,9 @@ ___
 
 ### node
 
-• `Readonly` **node**: `ConstructNode`
+• `Readonly` **node**: `Node`
 
-The construct tree node associated with this construct.
+The tree node.
 
 **`stability`** stable
 
@@ -91,133 +85,6 @@ The construct tree node associated with this construct.
 Construct.node
 
 ## Methods
-
-### onPrepare
-
-▸ `Protected` **onPrepare**(): `void`
-
-Perform final modifications before synthesis.
-
-This method can be implemented by derived constructs in order to perform
-final changes before synthesis. prepare() will be called after child
-constructs have been prepared.
-
-This is an advanced framework feature. Only use this if you
-understand the implications.
-
-**`stability`** stable
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.onPrepare
-
-___
-
-### onSynthesize
-
-▸ `Protected` **onSynthesize**(`session`): `void`
-
-Allows this construct to emit artifacts into the cloud assembly during synthesis.
-
-This method is usually implemented by framework-level constructs such as `Stack` and `Asset`
-as they participate in synthesizing the cloud assembly.
-
-**`stability`** stable
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `session` | `ISynthesisSession` | The synthesis session. |
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.onSynthesize
-
-___
-
-### onValidate
-
-▸ `Protected` **onValidate**(): `string`[]
-
-Validate the current construct.
-
-This method can be implemented by derived constructs in order to perform
-validation logic. It is called on all constructs before synthesis.
-
-**`stability`** stable
-
-#### Returns
-
-`string`[]
-
-An array of validation error messages, or an empty array if the construct is valid.
-
-#### Inherited from
-
-Construct.onValidate
-
-___
-
-### prepare
-
-▸ `Protected` **prepare**(): `void`
-
-Perform final modifications before synthesis.
-
-This method can be implemented by derived constructs in order to perform
-final changes before synthesis. prepare() will be called after child
-constructs have been prepared.
-
-This is an advanced framework feature. Only use this if you
-understand the implications.
-
-**`stability`** stable
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.prepare
-
-___
-
-### synthesize
-
-▸ `Protected` **synthesize**(`session`): `void`
-
-Allows this construct to emit artifacts into the cloud assembly during synthesis.
-
-This method is usually implemented by framework-level constructs such as `Stack` and `Asset`
-as they participate in synthesizing the cloud assembly.
-
-**`stability`** stable
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `session` | `ISynthesisSession` | The synthesis session. |
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.synthesize
-
-___
 
 ### toString
 
@@ -237,46 +104,25 @@ Construct.toString
 
 ___
 
-### validate
-
-▸ `Protected` **validate**(): `string`[]
-
-Validate the current construct.
-
-This method can be implemented by derived constructs in order to perform
-validation logic. It is called on all constructs before synthesis.
-
-**`stability`** stable
-
-#### Returns
-
-`string`[]
-
-An array of validation error messages, or an empty array if the construct is valid.
-
-#### Inherited from
-
-Construct.validate
-
-___
-
 ### isConstruct
 
 ▸ `Static` **isConstruct**(`x`): x is Construct
 
-Return whether the given object is a Construct.
+(deprecated) Checks if `x` is a construct.
 
-**`stability`** stable
+**`deprecated`** use `x instanceof Construct` instead
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `x` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `x` | `any` | Any object. |
 
 #### Returns
 
 x is Construct
+
+true if `x` is an object created from a class which extends `Construct`.
 
 #### Inherited from
 
@@ -308,13 +154,7 @@ Construct.isConstruct
 ### Methods
 
 - [onOverridden](#onoverridden)
-- [onPrepare](#onprepare)
-- [onSynthesize](#onsynthesize)
-- [onValidate](#onvalidate)
-- [prepare](#prepare)
-- [synthesize](#synthesize)
 - [toString](#tostring)
-- [validate](#validate)
 - [isConstruct](#isconstruct)
 
 ## Constructors
@@ -339,9 +179,9 @@ Construct.constructor
 
 ### node
 
-• `Readonly` **node**: `ConstructNode`
+• `Readonly` **node**: `Node`
 
-The construct tree node associated with this construct.
+The tree node.
 
 **`stability`** stable
 
@@ -374,133 +214,6 @@ ___
 
 ___
 
-### onPrepare
-
-▸ `Protected` **onPrepare**(): `void`
-
-Perform final modifications before synthesis.
-
-This method can be implemented by derived constructs in order to perform
-final changes before synthesis. prepare() will be called after child
-constructs have been prepared.
-
-This is an advanced framework feature. Only use this if you
-understand the implications.
-
-**`stability`** stable
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.onPrepare
-
-___
-
-### onSynthesize
-
-▸ `Protected` **onSynthesize**(`session`): `void`
-
-Allows this construct to emit artifacts into the cloud assembly during synthesis.
-
-This method is usually implemented by framework-level constructs such as `Stack` and `Asset`
-as they participate in synthesizing the cloud assembly.
-
-**`stability`** stable
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `session` | `ISynthesisSession` | The synthesis session. |
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.onSynthesize
-
-___
-
-### onValidate
-
-▸ `Protected` **onValidate**(): `string`[]
-
-Validate the current construct.
-
-This method can be implemented by derived constructs in order to perform
-validation logic. It is called on all constructs before synthesis.
-
-**`stability`** stable
-
-#### Returns
-
-`string`[]
-
-An array of validation error messages, or an empty array if the construct is valid.
-
-#### Inherited from
-
-Construct.onValidate
-
-___
-
-### prepare
-
-▸ `Protected` **prepare**(): `void`
-
-Perform final modifications before synthesis.
-
-This method can be implemented by derived constructs in order to perform
-final changes before synthesis. prepare() will be called after child
-constructs have been prepared.
-
-This is an advanced framework feature. Only use this if you
-understand the implications.
-
-**`stability`** stable
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.prepare
-
-___
-
-### synthesize
-
-▸ `Protected` **synthesize**(`session`): `void`
-
-Allows this construct to emit artifacts into the cloud assembly during synthesis.
-
-This method is usually implemented by framework-level constructs such as `Stack` and `Asset`
-as they participate in synthesizing the cloud assembly.
-
-**`stability`** stable
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `session` | `ISynthesisSession` | The synthesis session. |
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.synthesize
-
-___
-
 ### toString
 
 ▸ **toString**(): `string`
@@ -519,46 +232,25 @@ Construct.toString
 
 ___
 
-### validate
-
-▸ `Protected` **validate**(): `string`[]
-
-Validate the current construct.
-
-This method can be implemented by derived constructs in order to perform
-validation logic. It is called on all constructs before synthesis.
-
-**`stability`** stable
-
-#### Returns
-
-`string`[]
-
-An array of validation error messages, or an empty array if the construct is valid.
-
-#### Inherited from
-
-Construct.validate
-
-___
-
 ### isConstruct
 
 ▸ `Static` **isConstruct**(`x`): x is Construct
 
-Return whether the given object is a Construct.
+(deprecated) Checks if `x` is a construct.
 
-**`stability`** stable
+**`deprecated`** use `x instanceof Construct` instead
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `x` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `x` | `any` | Any object. |
 
 #### Returns
 
 x is Construct
+
+true if `x` is an object created from a class which extends `Construct`.
 
 #### Inherited from
 

--- a/packages/cdk-pull-request-approval-rule/package.json
+++ b/packages/cdk-pull-request-approval-rule/package.json
@@ -61,20 +61,12 @@
     }
   },
   "peerDependencies": {
-    "@aws-cdk/aws-codecommit": "^1.140.0",
-    "@aws-cdk/aws-events": "^1.140.0",
-    "@aws-cdk/core": "^1.140.0",
-    "constructs": "^3.2.0"
-  },
-  "dependencies": {
-    "@aws-cdk/aws-codecommit": "^1.140.0",
-    "@aws-cdk/aws-events": "^1.140.0",
-    "@aws-cdk/core": "^1.140.0"
+    "aws-cdk-lib": "^2.8.0",
+    "constructs": "^10.0.41"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "^1.140.0",
-    "@aws-cdk/aws-events-targets": "^1.140.0",
-    "@aws-cdk/aws-sns": "^1.140.0",
+    "aws-cdk-lib": "2.8.0",
+    "constructs": "10.0.41",
     "aws-sdk": "^2.1062.0",
     "jest-cdk-snapshot": "^1.4.2"
   },

--- a/packages/cdk-pull-request-approval-rule/src/__tests__/__snapshots__/approval-rule-template-repository-association.test.ts.snap
+++ b/packages/cdk-pull-request-approval-rule/src/__tests__/__snapshots__/approval-rule-template-repository-association.test.ts.snap
@@ -3,17 +3,10 @@
 exports[`default setup 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dArtifactHash3F913995": Object {
-      "Description": "Artifact hash for asset \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
-    },
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3BucketB0535DA6": Object {
-      "Description": "S3 bucket for asset \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
-    },
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553": Object {
-      "Description": "S3 key for asset version \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": Object {
@@ -44,41 +37,9 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3BucketB0535DA6",
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
+          "S3Key": "f8ca1d29c644a0833008ab90807761903f708f8de014e13f60ab16eff2d0d48c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -88,7 +49,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -140,23 +101,43 @@ Object {
       "Type": "AWS::CodeCommit::Repository",
     },
   },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
 }
 `;
 
 exports[`onOverridden 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dArtifactHash3F913995": Object {
-      "Description": "Artifact hash for asset \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
-    },
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3BucketB0535DA6": Object {
-      "Description": "S3 bucket for asset \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
-    },
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553": Object {
-      "Description": "S3 key for asset version \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": Object {
@@ -187,41 +168,9 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3BucketB0535DA6",
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
+          "S3Key": "f8ca1d29c644a0833008ab90807761903f708f8de014e13f60ab16eff2d0d48c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -231,7 +180,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -345,6 +294,33 @@ Object {
         ],
       },
       "Type": "AWS::SNS::TopicPolicy",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
     },
   },
 }

--- a/packages/cdk-pull-request-approval-rule/src/__tests__/__snapshots__/approval-rule-template.test.ts.snap
+++ b/packages/cdk-pull-request-approval-rule/src/__tests__/__snapshots__/approval-rule-template.test.ts.snap
@@ -3,17 +3,10 @@
 exports[`default setup 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dArtifactHash3F913995": Object {
-      "Description": "Artifact hash for asset \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
-    },
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3BucketB0535DA6": Object {
-      "Description": "S3 bucket for asset \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
-    },
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553": Object {
-      "Description": "S3 key for asset version \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": Object {
@@ -43,41 +36,9 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3BucketB0535DA6",
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
+          "S3Key": "f8ca1d29c644a0833008ab90807761903f708f8de014e13f60ab16eff2d0d48c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -87,7 +48,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -137,23 +98,43 @@ Object {
       "Type": "AWS::IAM::Role",
     },
   },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
 }
 `;
 
 exports[`list of approvalPoolMembers 1`] = `
 Object {
   "Parameters": Object {
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dArtifactHash3F913995": Object {
-      "Description": "Artifact hash for asset \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
-    },
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3BucketB0535DA6": Object {
-      "Description": "S3 bucket for asset \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
-    },
-    "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553": Object {
-      "Description": "S3 key for asset version \\"ebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39d\\"",
-      "Type": "String",
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
   },
   "Resources": Object {
@@ -187,41 +168,9 @@ Object {
       "Properties": Object {
         "Code": Object {
           "S3Bucket": Object {
-            "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3BucketB0535DA6",
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": Object {
-            "Fn::Join": Array [
-              "",
-              Array [
-                Object {
-                  "Fn::Select": Array [
-                    0,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553",
-                        },
-                      ],
-                    },
-                  ],
-                },
-                Object {
-                  "Fn::Select": Array [
-                    1,
-                    Object {
-                      "Fn::Split": Array [
-                        "||",
-                        Object {
-                          "Ref": "AssetParametersebb733d6e04a5bf2fbe4150c006031a3d5eec4a25b0df83c71ec65e72828b39dS3VersionKey2422C553",
-                        },
-                      ],
-                    },
-                  ],
-                },
-              ],
-            ],
-          },
+          "S3Key": "f8ca1d29c644a0833008ab90807761903f708f8de014e13f60ab16eff2d0d48c.zip",
         },
         "Handler": "__entrypoint__.handler",
         "MemorySize": 128,
@@ -231,7 +180,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "Timeout": 900,
       },
       "Type": "AWS::Lambda::Function",
@@ -279,6 +228,33 @@ Object {
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
     },
   },
 }

--- a/packages/cdk-pull-request-approval-rule/src/__tests__/approval-rule-template-repository-association.test.ts
+++ b/packages/cdk-pull-request-approval-rule/src/__tests__/approval-rule-template-repository-association.test.ts
@@ -1,8 +1,8 @@
 import * as path from 'path';
-import { Repository } from '@aws-cdk/aws-codecommit';
-import { SnsTopic } from '@aws-cdk/aws-events-targets';
-import { Topic } from '@aws-cdk/aws-sns';
-import { Stack } from '@aws-cdk/core';
+import { Stack } from 'aws-cdk-lib';
+import { Repository } from 'aws-cdk-lib/aws-codecommit';
+import { SnsTopic } from 'aws-cdk-lib/aws-events-targets';
+import { Topic } from 'aws-cdk-lib/aws-sns';
 import 'jest-cdk-snapshot';
 
 import { ApprovalRuleTemplateRepositoryAssociation } from '../approval-rule-template-repository-association';

--- a/packages/cdk-pull-request-approval-rule/src/__tests__/approval-rule-template.test.ts
+++ b/packages/cdk-pull-request-approval-rule/src/__tests__/approval-rule-template.test.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { Stack } from '@aws-cdk/core';
+import { Stack } from 'aws-cdk-lib';
 import 'jest-cdk-snapshot';
 
 import { ApprovalRuleTemplate } from '../approval-rule-template';

--- a/packages/cdk-pull-request-approval-rule/src/approval-rule-template-repository-association.ts
+++ b/packages/cdk-pull-request-approval-rule/src/approval-rule-template-repository-association.ts
@@ -1,6 +1,7 @@
-import { IRepository } from '@aws-cdk/aws-codecommit';
-import { OnEventOptions, Rule } from '@aws-cdk/aws-events';
-import { Construct, CustomResource, CustomResourceProvider, CustomResourceProviderRuntime } from '@aws-cdk/core';
+import { CustomResource, CustomResourceProvider, CustomResourceProviderRuntime } from 'aws-cdk-lib';
+import { IRepository } from 'aws-cdk-lib/aws-codecommit';
+import { OnEventOptions, Rule } from 'aws-cdk-lib/aws-events';
+import { Construct } from 'constructs';
 
 import { approvalRuleTemplateRepositoryAssociationDir } from './directories';
 
@@ -28,7 +29,7 @@ export class ApprovalRuleTemplateRepositoryAssociation extends Construct {
 
     const serviceToken = CustomResourceProvider.getOrCreate(this, resourceType, {
       codeDirectory: approvalRuleTemplateRepositoryAssociationDir,
-      runtime: CustomResourceProviderRuntime.NODEJS_12,
+      runtime: CustomResourceProviderRuntime.NODEJS_14_X,
       policyStatements: [
         {
           Effect: 'Allow',

--- a/packages/cdk-pull-request-approval-rule/src/approval-rule-template.ts
+++ b/packages/cdk-pull-request-approval-rule/src/approval-rule-template.ts
@@ -1,4 +1,5 @@
-import { Construct, CustomResource, CustomResourceProvider, CustomResourceProviderRuntime } from '@aws-cdk/core';
+import { CustomResource, CustomResourceProvider, CustomResourceProviderRuntime } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
 
 import { approvalRuleTemplateDir } from './directories';
 
@@ -39,7 +40,7 @@ export class ApprovalRuleTemplate extends Construct {
 
     const serviceToken = CustomResourceProvider.getOrCreate(this, 'Custom::ApprovalRuleTemplate', {
       codeDirectory: approvalRuleTemplateDir,
-      runtime: CustomResourceProviderRuntime.NODEJS_12,
+      runtime: CustomResourceProviderRuntime.NODEJS_14_X,
       policyStatements: [
         {
           Effect: 'Allow',

--- a/packages/cdk-pull-request-check/API.md
+++ b/packages/cdk-pull-request-check/API.md
@@ -46,13 +46,7 @@ Represents a reference to a PullRequestCheck.
 - [onCheckFailed](#oncheckfailed)
 - [onCheckStarted](#oncheckstarted)
 - [onCheckSucceeded](#onchecksucceeded)
-- [onPrepare](#onprepare)
-- [onSynthesize](#onsynthesize)
-- [onValidate](#onvalidate)
-- [prepare](#prepare)
-- [synthesize](#synthesize)
 - [toString](#tostring)
-- [validate](#validate)
 - [isConstruct](#isconstruct)
 
 ## Constructors
@@ -83,9 +77,9 @@ ___
 
 ### node
 
-• `Readonly` **node**: `ConstructNode`
+• `Readonly` **node**: `Node`
 
-The construct tree node associated with this construct.
+The tree node.
 
 **`stability`** stable
 
@@ -176,133 +170,6 @@ Defines an event rule which triggers when a check complets successfully.
 
 ___
 
-### onPrepare
-
-▸ `Protected` **onPrepare**(): `void`
-
-Perform final modifications before synthesis.
-
-This method can be implemented by derived constructs in order to perform
-final changes before synthesis. prepare() will be called after child
-constructs have been prepared.
-
-This is an advanced framework feature. Only use this if you
-understand the implications.
-
-**`stability`** stable
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.onPrepare
-
-___
-
-### onSynthesize
-
-▸ `Protected` **onSynthesize**(`session`): `void`
-
-Allows this construct to emit artifacts into the cloud assembly during synthesis.
-
-This method is usually implemented by framework-level constructs such as `Stack` and `Asset`
-as they participate in synthesizing the cloud assembly.
-
-**`stability`** stable
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `session` | `ISynthesisSession` | The synthesis session. |
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.onSynthesize
-
-___
-
-### onValidate
-
-▸ `Protected` **onValidate**(): `string`[]
-
-Validate the current construct.
-
-This method can be implemented by derived constructs in order to perform
-validation logic. It is called on all constructs before synthesis.
-
-**`stability`** stable
-
-#### Returns
-
-`string`[]
-
-An array of validation error messages, or an empty array if the construct is valid.
-
-#### Inherited from
-
-Construct.onValidate
-
-___
-
-### prepare
-
-▸ `Protected` **prepare**(): `void`
-
-Perform final modifications before synthesis.
-
-This method can be implemented by derived constructs in order to perform
-final changes before synthesis. prepare() will be called after child
-constructs have been prepared.
-
-This is an advanced framework feature. Only use this if you
-understand the implications.
-
-**`stability`** stable
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.prepare
-
-___
-
-### synthesize
-
-▸ `Protected` **synthesize**(`session`): `void`
-
-Allows this construct to emit artifacts into the cloud assembly during synthesis.
-
-This method is usually implemented by framework-level constructs such as `Stack` and `Asset`
-as they participate in synthesizing the cloud assembly.
-
-**`stability`** stable
-
-#### Parameters
-
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `session` | `ISynthesisSession` | The synthesis session. |
-
-#### Returns
-
-`void`
-
-#### Inherited from
-
-Construct.synthesize
-
-___
-
 ### toString
 
 ▸ **toString**(): `string`
@@ -321,46 +188,25 @@ Construct.toString
 
 ___
 
-### validate
-
-▸ `Protected` **validate**(): `string`[]
-
-Validate the current construct.
-
-This method can be implemented by derived constructs in order to perform
-validation logic. It is called on all constructs before synthesis.
-
-**`stability`** stable
-
-#### Returns
-
-`string`[]
-
-An array of validation error messages, or an empty array if the construct is valid.
-
-#### Inherited from
-
-Construct.validate
-
-___
-
 ### isConstruct
 
 ▸ `Static` **isConstruct**(`x`): x is Construct
 
-Return whether the given object is a Construct.
+(deprecated) Checks if `x` is a construct.
 
-**`stability`** stable
+**`deprecated`** use `x instanceof Construct` instead
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `x` | `any` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `x` | `any` | Any object. |
 
 #### Returns
 
 x is Construct
+
+true if `x` is an object created from a class which extends `Construct`.
 
 #### Inherited from
 

--- a/packages/cdk-pull-request-check/package.json
+++ b/packages/cdk-pull-request-check/package.json
@@ -66,8 +66,7 @@
     "aws-cdk-lib": "2.8.0",
     "constructs": "10.0.41",
     "aws-sdk": "^2.1062.0",
-    "get-env-or-die": "^1.0.11",
-    "jest-cdk-snapshot": "^2.0.1"
+    "get-env-or-die": "^1.0.11"
   },
   "externals": [
     "aws-sdk"

--- a/packages/cdk-pull-request-check/package.json
+++ b/packages/cdk-pull-request-check/package.json
@@ -59,32 +59,15 @@
     }
   },
   "peerDependencies": {
-    "@aws-cdk/aws-codebuild": "^1.140.0",
-    "@aws-cdk/aws-codecommit": "^1.140.0",
-    "@aws-cdk/aws-ec2": "^1.140.0",
-    "@aws-cdk/aws-events": "^1.140.0",
-    "@aws-cdk/aws-events-targets": "^1.140.0",
-    "@aws-cdk/aws-iam": "^1.140.0",
-    "@aws-cdk/aws-lambda": "^1.140.0",
-    "@aws-cdk/core": "^1.140.0",
-    "constructs": "^3.2.0"
-  },
-  "dependencies": {
-    "@aws-cdk/aws-codebuild": "^1.140.0",
-    "@aws-cdk/aws-codecommit": "^1.140.0",
-    "@aws-cdk/aws-ec2": "^1.140.0",
-    "@aws-cdk/aws-events": "^1.140.0",
-    "@aws-cdk/aws-events-targets": "^1.140.0",
-    "@aws-cdk/aws-iam": "^1.140.0",
-    "@aws-cdk/aws-lambda": "^1.140.0",
-    "@aws-cdk/core": "^1.140.0"
+    "aws-cdk-lib": "^2.8.0",
+    "constructs": "^10.0.41"
   },
   "devDependencies": {
-    "@aws-cdk/assert": "^1.140.0",
-    "@aws-cdk/aws-sns": "^1.140.0",
+    "aws-cdk-lib": "2.8.0",
+    "constructs": "10.0.41",
     "aws-sdk": "^2.1062.0",
     "get-env-or-die": "^1.0.11",
-    "jest-cdk-snapshot": "^1.4.2"
+    "jest-cdk-snapshot": "^2.0.1"
   },
   "externals": [
     "aws-sdk"

--- a/packages/cdk-pull-request-check/src/__tests__/__snapshots__/pull-request-check.test.ts.snap
+++ b/packages/cdk-pull-request-check/src/__tests__/__snapshots__/pull-request-check.test.ts.snap
@@ -2,7 +2,13 @@
 
 exports[`custom projectName 1`] = `
 Object {
-  "Parameters": Any<Object>,
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
   "Resources": Object {
     "PullRequestCheckCodeBuildResultFunctionE246172A": Object {
       "DependsOn": Array [
@@ -10,7 +16,12 @@ Object {
         "PullRequestCheckCodeBuildResultFunctionServiceRole18C3CF5B",
       ],
       "Properties": Object {
-        "Code": Any<Object>,
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c662fdaec2573111fc66de19d48f7f1137ac86dad620fab7a3a7ae0b5593cfb5.zip",
+        },
         "Environment": Object {
           "Variables": Object {
             "POST_COMMENT": "TRUE",
@@ -447,7 +458,13 @@ Object {
 
 exports[`custom setup 1`] = `
 Object {
-  "Parameters": Any<Object>,
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
   "Resources": Object {
     "PullRequestCheckCodeBuildResultFunctionE246172A": Object {
       "DependsOn": Array [
@@ -455,7 +472,12 @@ Object {
         "PullRequestCheckCodeBuildResultFunctionServiceRole18C3CF5B",
       ],
       "Properties": Object {
-        "Code": Any<Object>,
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c662fdaec2573111fc66de19d48f7f1137ac86dad620fab7a3a7ae0b5593cfb5.zip",
+        },
         "Environment": Object {
           "Variables": Object {
             "POST_COMMENT": "TRUE",
@@ -905,7 +927,13 @@ Object {
 
 exports[`default setup 1`] = `
 Object {
-  "Parameters": Any<Object>,
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
   "Resources": Object {
     "PullRequestCheckCodeBuildResultFunctionE246172A": Object {
       "DependsOn": Array [
@@ -913,7 +941,12 @@ Object {
         "PullRequestCheckCodeBuildResultFunctionServiceRole18C3CF5B",
       ],
       "Properties": Object {
-        "Code": Any<Object>,
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c662fdaec2573111fc66de19d48f7f1137ac86dad620fab7a3a7ae0b5593cfb5.zip",
+        },
         "Environment": Object {
           "Variables": Object {
             "POST_COMMENT": "TRUE",
@@ -1363,7 +1396,13 @@ Object {
 
 exports[`events 1`] = `
 Object {
-  "Parameters": Any<Object>,
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
   "Resources": Object {
     "PullRequestCheckCodeBuildResultFunctionE246172A": Object {
       "DependsOn": Array [
@@ -1371,7 +1410,12 @@ Object {
         "PullRequestCheckCodeBuildResultFunctionServiceRole18C3CF5B",
       ],
       "Properties": Object {
-        "Code": Any<Object>,
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c662fdaec2573111fc66de19d48f7f1137ac86dad620fab7a3a7ae0b5593cfb5.zip",
+        },
         "Environment": Object {
           "Variables": Object {
             "POST_COMMENT": "TRUE",
@@ -1945,7 +1989,13 @@ Object {
 
 exports[`privileged 1`] = `
 Object {
-  "Parameters": Any<Object>,
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
   "Resources": Object {
     "PullRequestCheckCodeBuildResultFunctionE246172A": Object {
       "DependsOn": Array [
@@ -1953,7 +2003,12 @@ Object {
         "PullRequestCheckCodeBuildResultFunctionServiceRole18C3CF5B",
       ],
       "Properties": Object {
-        "Code": Any<Object>,
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c662fdaec2573111fc66de19d48f7f1137ac86dad620fab7a3a7ae0b5593cfb5.zip",
+        },
         "Environment": Object {
           "Variables": Object {
             "POST_COMMENT": "TRUE",
@@ -2403,7 +2458,13 @@ Object {
 
 exports[`randomizer 1`] = `
 Object {
-  "Parameters": Any<Object>,
+  "Parameters": Object {
+    "BootstrapVersion": Object {
+      "Default": "/cdk-bootstrap/hnb659fds/version",
+      "Description": "Version of the CDK Bootstrap resources in this environment, automatically retrieved from SSM Parameter Store. [cdk:skip]",
+      "Type": "AWS::SSM::Parameter::Value<String>",
+    },
+  },
   "Resources": Object {
     "PullRequestCheck1CodeBuildResultFunction92561847": Object {
       "DependsOn": Array [
@@ -2411,7 +2472,12 @@ Object {
         "PullRequestCheck1CodeBuildResultFunctionServiceRole56BD8BE4",
       ],
       "Properties": Object {
-        "Code": Any<Object>,
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c662fdaec2573111fc66de19d48f7f1137ac86dad620fab7a3a7ae0b5593cfb5.zip",
+        },
         "Environment": Object {
           "Variables": Object {
             "POST_COMMENT": "TRUE",
@@ -2759,7 +2825,12 @@ Object {
         "PullRequestCheck2CodeBuildResultFunctionServiceRole5CE92E16",
       ],
       "Properties": Object {
-        "Code": Any<Object>,
+        "Code": Object {
+          "S3Bucket": Object {
+            "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
+          },
+          "S3Key": "c662fdaec2573111fc66de19d48f7f1137ac86dad620fab7a3a7ae0b5593cfb5.zip",
+        },
         "Environment": Object {
           "Variables": Object {
             "POST_COMMENT": "TRUE",

--- a/packages/cdk-pull-request-check/src/__tests__/__snapshots__/pull-request-check.test.ts.snap
+++ b/packages/cdk-pull-request-check/src/__tests__/__snapshots__/pull-request-check.test.ts.snap
@@ -24,7 +24,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -142,7 +142,7 @@ Object {
         "EncryptionKey": "alias/aws/s3",
         "Environment": Object {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:4.0",
+          "Image": "aws/codebuild/standard:5.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER",
@@ -415,6 +415,33 @@ Object {
       "Type": "AWS::Events::Rule",
     },
   },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
 }
 `;
 
@@ -442,7 +469,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -560,7 +587,7 @@ Object {
         "EncryptionKey": "alias/aws/s3",
         "Environment": Object {
           "ComputeType": "BUILD_GENERAL1_LARGE",
-          "Image": "aws/codebuild/python:3.7.1",
+          "Image": "aws/codebuild/standard:5.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER",
@@ -844,6 +871,33 @@ Object {
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
     },
   },
 }
@@ -873,7 +927,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -991,7 +1045,7 @@ Object {
         "EncryptionKey": "alias/aws/s3",
         "Environment": Object {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:4.0",
+          "Image": "aws/codebuild/standard:5.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER",
@@ -1277,6 +1331,33 @@ Object {
       "Type": "AWS::Events::Rule",
     },
   },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
 }
 `;
 
@@ -1304,7 +1385,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -1422,7 +1503,7 @@ Object {
         "EncryptionKey": "alias/aws/s3",
         "Environment": Object {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:4.0",
+          "Image": "aws/codebuild/standard:5.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER",
@@ -1832,6 +1913,33 @@ Object {
       "Type": "AWS::SNS::TopicPolicy",
     },
   },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
 }
 `;
 
@@ -1859,7 +1967,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -1977,7 +2085,7 @@ Object {
         "EncryptionKey": "alias/aws/s3",
         "Environment": Object {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:4.0",
+          "Image": "aws/codebuild/standard:5.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": true,
           "Type": "LINUX_CONTAINER",
@@ -2263,6 +2371,33 @@ Object {
       "Type": "AWS::Events::Rule",
     },
   },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
+    },
+  },
 }
 `;
 
@@ -2290,7 +2425,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -2365,7 +2500,7 @@ Object {
         "EncryptionKey": "alias/aws/s3",
         "Environment": Object {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:4.0",
+          "Image": "aws/codebuild/standard:5.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER",
@@ -2638,7 +2773,7 @@ Object {
             "Arn",
           ],
         },
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
       },
       "Type": "AWS::Lambda::Function",
     },
@@ -2713,7 +2848,7 @@ Object {
         "EncryptionKey": "alias/aws/s3",
         "Environment": Object {
           "ComputeType": "BUILD_GENERAL1_SMALL",
-          "Image": "aws/codebuild/standard:4.0",
+          "Image": "aws/codebuild/standard:5.0",
           "ImagePullCredentialsType": "CODEBUILD",
           "PrivilegedMode": false,
           "Type": "LINUX_CONTAINER",
@@ -3081,6 +3216,33 @@ Object {
         ],
       },
       "Type": "AWS::Events::Rule",
+    },
+  },
+  "Rules": Object {
+    "CheckBootstrapVersion": Object {
+      "Assertions": Array [
+        Object {
+          "Assert": Object {
+            "Fn::Not": Array [
+              Object {
+                "Fn::Contains": Array [
+                  Array [
+                    "1",
+                    "2",
+                    "3",
+                    "4",
+                    "5",
+                  ],
+                  Object {
+                    "Ref": "BootstrapVersion",
+                  },
+                ],
+              },
+            ],
+          },
+          "AssertDescription": "CDK bootstrap stack version 6 required. Please run 'cdk bootstrap' with a recent version of the CDK CLI.",
+        },
+      ],
     },
   },
 }

--- a/packages/cdk-pull-request-check/src/__tests__/pull-request-check.test.ts
+++ b/packages/cdk-pull-request-check/src/__tests__/pull-request-check.test.ts
@@ -1,9 +1,9 @@
 import { Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
 import { BuildSpec, ComputeType, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
 import { Repository } from 'aws-cdk-lib/aws-codecommit';
 import { SnsTopic } from 'aws-cdk-lib/aws-events-targets';
 import { Topic } from 'aws-cdk-lib/aws-sns';
-import 'jest-cdk-snapshot';
 
 import { PullRequestCheck } from '../pull-request-check';
 
@@ -23,9 +23,8 @@ test('default setup', (): void => {
   });
 
   // THEN
-  expect(stack).toMatchCdkSnapshot({
-    ignoreAssets: true,
-  });
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
 });
 
 test('custom setup', (): void => {
@@ -46,9 +45,8 @@ test('custom setup', (): void => {
   });
 
   // THEN
-  expect(stack).toMatchCdkSnapshot({
-    ignoreAssets: true,
-  });
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
 });
 
 test('privileged', (): void => {
@@ -68,9 +66,8 @@ test('privileged', (): void => {
   });
 
   // THEN
-  expect(stack).toMatchCdkSnapshot({
-    ignoreAssets: true,
-  });
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
 });
 
 test('custom projectName', (): void => {
@@ -90,9 +87,8 @@ test('custom projectName', (): void => {
   });
 
   // THEN
-  expect(stack).toMatchCdkSnapshot({
-    ignoreAssets: true,
-  });
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
 });
 
 test('events', (): void => {
@@ -118,9 +114,8 @@ test('events', (): void => {
   prCheck.onCheckFailed('failed', { target: new SnsTopic(topic) });
 
   // THEN
-  expect(stack).toMatchCdkSnapshot({
-    ignoreAssets: true,
-  });
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
 });
 
 test('randomizer', (): void => {
@@ -145,7 +140,6 @@ test('randomizer', (): void => {
   });
 
   // THEN
-  expect(stack).toMatchCdkSnapshot({
-    ignoreAssets: true,
-  });
+  const template = Template.fromStack(stack);
+  expect(template.toJSON()).toMatchSnapshot();
 });

--- a/packages/cdk-pull-request-check/src/__tests__/pull-request-check.test.ts
+++ b/packages/cdk-pull-request-check/src/__tests__/pull-request-check.test.ts
@@ -1,8 +1,8 @@
-import { BuildSpec, ComputeType, LinuxBuildImage } from '@aws-cdk/aws-codebuild';
-import { Repository } from '@aws-cdk/aws-codecommit';
-import { SnsTopic } from '@aws-cdk/aws-events-targets';
-import { Topic } from '@aws-cdk/aws-sns';
-import { Stack } from '@aws-cdk/core';
+import { Stack } from 'aws-cdk-lib';
+import { BuildSpec, ComputeType, LinuxBuildImage } from 'aws-cdk-lib/aws-codebuild';
+import { Repository } from 'aws-cdk-lib/aws-codecommit';
+import { SnsTopic } from 'aws-cdk-lib/aws-events-targets';
+import { Topic } from 'aws-cdk-lib/aws-sns';
 import 'jest-cdk-snapshot';
 
 import { PullRequestCheck } from '../pull-request-check';
@@ -42,7 +42,7 @@ test('custom setup', (): void => {
     repository,
     buildSpec: BuildSpec.fromSourceFilename('buildspecs/prcheck.yml'),
     computeType: ComputeType.LARGE,
-    buildImage: LinuxBuildImage.UBUNTU_14_04_PYTHON_3_7_1,
+    buildImage: LinuxBuildImage.STANDARD_5_0,
   });
 
   // THEN

--- a/packages/cdk-pull-request-check/src/pull-request-check.ts
+++ b/packages/cdk-pull-request-check/src/pull-request-check.ts
@@ -1,12 +1,21 @@
 import * as path from 'path';
-import { BuildSpec, ComputeType, IBuildImage, LinuxBuildImage, Project, Source, BuildEnvironmentVariable, IArtifacts } from '@aws-cdk/aws-codebuild';
-import { IRepository } from '@aws-cdk/aws-codecommit';
-import { IVpc, SubnetSelection, ISecurityGroup } from '@aws-cdk/aws-ec2';
-import { EventField, RuleTargetInput, OnEventOptions, Rule } from '@aws-cdk/aws-events';
-import { CodeBuildProject, LambdaFunction } from '@aws-cdk/aws-events-targets';
-import { PolicyStatement, Effect, IRole } from '@aws-cdk/aws-iam';
-import { Code, Function, IFunction, Runtime } from '@aws-cdk/aws-lambda';
-import { Construct } from '@aws-cdk/core';
+import {
+  BuildEnvironmentVariable,
+  BuildSpec,
+  ComputeType,
+  IArtifacts,
+  IBuildImage,
+  LinuxBuildImage,
+  Project,
+  Source,
+} from 'aws-cdk-lib/aws-codebuild';
+import { IRepository } from 'aws-cdk-lib/aws-codecommit';
+import { ISecurityGroup, IVpc, SubnetSelection } from 'aws-cdk-lib/aws-ec2';
+import { EventField, OnEventOptions, Rule, RuleTargetInput } from 'aws-cdk-lib/aws-events';
+import { CodeBuildProject, LambdaFunction } from 'aws-cdk-lib/aws-events-targets';
+import { Effect, IRole, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { Code, Function, IFunction, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
 
 export interface PullRequestCheckProps {
   /**
@@ -134,7 +143,7 @@ export class PullRequestCheck extends Construct {
     const {
       repository,
       buildSpec,
-      buildImage = LinuxBuildImage.STANDARD_4_0,
+      buildImage = LinuxBuildImage.STANDARD_5_0,
       computeType = buildImage.defaultComputeType,
       privileged = false,
       updateApprovalState = true,
@@ -171,7 +180,7 @@ export class PullRequestCheck extends Construct {
 
     if (updateApprovalState || postComment) {
       this.codeBuildResultFunction = new Function(this, 'CodeBuildResultFunction', {
-        runtime: Runtime.NODEJS_12_X,
+        runtime: Runtime.NODEJS_14_X,
         code: Code.fromAsset(path.join(__dirname, 'lambdas', 'code-build-result')),
         handler: 'index.handler',
         environment: {


### PR DESCRIPTION
Migration of cdk-pull-request-check and cdk-pull-request-approval-rule to cdkv2.

Changes:
- Change to Node14 in the Lambda functions and LinuxBuildImage Standard 5.
- As discussion, I use aws-cdk-lib/assertions for pull-request-check tests