### PR TITLE
feat: add support for github webhook secret

### DIFF
--- a/examples/github-webhook-example/src/github-webhook-stack.ts
+++ b/examples/github-webhook-example/src/github-webhook-stack.ts
@@ -18,12 +18,16 @@ export class GithubWebhookStack extends Stack {
     // @see https://developer.github.com/v3/activity/events/types/
     const events = ['*'];
 
+    // @see https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github
+    const webhookSecret = process.env.SECURE_WEBHOOK === 'true' ? (process.env.WEBHOOK_SECRET || githubApiToken.serialize()) : undefined
+
     new GithubWebhook(this, 'GithubWebhook', {
       githubApiToken,
       githubRepoUrl,
       payloadUrl: api.url,
       events,
       logLevel: 'debug',
+      webhookSecret
     });
   }
 }

--- a/packages/cdk-github-webhook/README.md
+++ b/packages/cdk-github-webhook/README.md
@@ -45,6 +45,9 @@ export class GithubWebhookStack extends Stack {
 
     // @see https://developer.github.com/v3/activity/events/types/
     const events = ['*'];
+ 
+    // @see https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github
+    const webhookSecret = process.env.SECURE_WEBHOOK === 'true' ? (process.env.WEBHOOK_SECRET || githubApiToken.serialize()) : undefined
 
     new GithubWebhook(this, 'GithubWebhook', {
       githubApiToken,
@@ -52,6 +55,7 @@ export class GithubWebhookStack extends Stack {
       payloadUrl: api.url,
       events,
       logLevel: 'debug',
+      webhookSecret
     });
   }
 }

--- a/packages/cdk-github-webhook/src/github-webhook.ts
+++ b/packages/cdk-github-webhook/src/github-webhook.ts
@@ -24,6 +24,12 @@ export interface GithubWebhookProps {
    * @see https://developer.github.com/v3/activity/events/types/
    */
   readonly events: string[];
+  /**
+   * The webhook secret that GitHub uses to create a
+   * hash signature with each payload
+   * @see https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github
+   */
+  readonly webhookSecret?: string
 
   readonly logLevel?: 'debug' | 'info' | 'warning' | 'error';
 }
@@ -57,6 +63,7 @@ export class GithubWebhook extends Construct {
         payloadUrl: props.payloadUrl,
         events: props.events,
         logLevel: props.logLevel,
+        webhookSecret: props.webhookSecret
       },
     });
   }

--- a/packages/cdk-github-webhook/src/lambdas/github-webhook/index.ts
+++ b/packages/cdk-github-webhook/src/lambdas/github-webhook/index.ts
@@ -17,10 +17,11 @@ export interface WebhookProps {
   githubRepoUrl: string;
   payloadUrl: string;
   events: string[];
+  webhookSecret?: string;
 }
 
 const handleCreate: OnCreateHandler = async (event): Promise<ResourceHandlerReturn> => {
-  const { githubApiTokenString, githubRepoUrl, payloadUrl, events } = camelizeKeys<
+  const { githubApiTokenString, githubRepoUrl, payloadUrl, events, webhookSecret } = camelizeKeys<
     WebhookProps,
     CloudFormationCustomResourceEventCommon['ResourceProperties']
   >(event.ResourceProperties);
@@ -28,7 +29,7 @@ const handleCreate: OnCreateHandler = async (event): Promise<ResourceHandlerRetu
   const secretKey = new SecretKey(githubApiTokenString);
   const githubApiToken = await secretKey.getValue();
 
-  const { data } = await createWebhook(githubApiToken, githubRepoUrl, payloadUrl, events);
+  const { data } = await createWebhook(githubApiToken, githubRepoUrl, payloadUrl, events, webhookSecret);
 
   const physicalResourceId = data.id.toString();
 
@@ -41,7 +42,7 @@ const handleCreate: OnCreateHandler = async (event): Promise<ResourceHandlerRetu
 };
 
 const handleUpdate: OnUpdateHandler = async (event): Promise<ResourceHandlerReturn> => {
-  const { githubApiTokenString, githubRepoUrl, payloadUrl, events } = camelizeKeys<
+  const { githubApiTokenString, githubRepoUrl, payloadUrl, events, webhookSecret } = camelizeKeys<
     WebhookProps,
     CloudFormationCustomResourceEventCommon['ResourceProperties']
   >(event.ResourceProperties);
@@ -51,7 +52,7 @@ const handleUpdate: OnUpdateHandler = async (event): Promise<ResourceHandlerRetu
 
   const hookId = event.PhysicalResourceId;
 
-  const { data } = await updateWebhook(githubApiToken, githubRepoUrl, payloadUrl, events, parseInt(hookId, 10));
+  const { data } = await updateWebhook(githubApiToken, githubRepoUrl, payloadUrl, events, parseInt(hookId, 10), webhookSecret);
 
   const physicalResourceId = data.id.toString();
 

--- a/packages/cdk-github-webhook/src/lambdas/github-webhook/webhook-api.ts
+++ b/packages/cdk-github-webhook/src/lambdas/github-webhook/webhook-api.ts
@@ -6,6 +6,7 @@ export const createWebhook = async (
   githubRepoUrl: string,
   payloadUrl: string,
   events: string[],
+  webhookSecret?: string
 ): Promise<RestEndpointMethodTypes['repos']['createWebhook']['response']> => {
   const octokit = new Octokit({
     auth: githubApiToken,
@@ -17,11 +18,16 @@ export const createWebhook = async (
     throw new Error('GithubRepoUrl is not correct');
   }
 
+  const config = { url: payloadUrl, content_type: 'json' };
+  if (webhookSecret != null) {
+    Object.assign(config, { secret: webhookSecret});
+  }
+
   const params = {
     name: 'web',
     owner: gh.owner,
     repo: gh.name,
-    config: { url: payloadUrl, content_type: 'json' },
+    config,
     events,
     active: true,
   };
@@ -35,6 +41,7 @@ export const updateWebhook = async (
   payloadUrl: string,
   events: string[],
   hookId: number,
+  webhookSecret?: string
 ): Promise<RestEndpointMethodTypes['repos']['updateWebhook']['response']> => {
   const octokit = new Octokit({
     auth: githubApiToken,
@@ -46,10 +53,15 @@ export const updateWebhook = async (
     throw new Error('GithubRepoUrl is not correct');
   }
 
+  const config = { url: payloadUrl, content_type: 'json' };
+  if (webhookSecret != null) {
+    Object.assign(config, { secret: webhookSecret});
+  }
+
   const params = {
     owner: gh.owner,
     repo: gh.name,
-    config: { url: payloadUrl, content_type: 'json' },
+    config,
     events,
     active: true,
     hook_id: hookId,


### PR DESCRIPTION
This adds a secret to the config of the webhook. Without it we are unable to verify webhook signatures in POST requests. See https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github