### PR TITLE
Add support for ECS Exec command

### DIFF
--- a/packages/cdk-blue-green-container-deployment/src/__tests__/ecs-service.test.ts
+++ b/packages/cdk-blue-green-container-deployment/src/__tests__/ecs-service.test.ts
@@ -91,4 +91,30 @@ describe('EcsService', () => {
       );
     });
   });
+
+    describe('with execute command', () => {
+        const stack = new cdk.Stack(app, 'MyStackWithExecute');
+        const cluster = new ecs.Cluster(stack, 'Cluster');
+        const prodTargetGroup = new elb.ApplicationTargetGroup(stack, 'ProdTargetGroup', { vpc: cluster.vpc });
+        const testTargetGroup = new elb.ApplicationTargetGroup(stack, 'TestTargetGroup', { vpc: cluster.vpc });
+        const taskDefinition = new DummyTaskDefinition(stack, 'DummyTaskDefinition', { image: 'nginx' });
+        const enableExecuteCommand = true
+
+        new EcsService(stack, 'Service', {
+            cluster,
+            serviceName: 'My Service',
+            prodTargetGroup,
+            testTargetGroup,
+            taskDefinition,
+            enableExecuteCommand
+        });
+
+        test('Creates a BlueGreenService custom resource', () => {
+            expectCDK(stack).to(
+                haveResource('Custom::BlueGreenService', {
+                    EnableExecuteCommand: true,
+                }),
+            );
+        });
+    });
 });

--- a/packages/cdk-blue-green-container-deployment/src/ecs-service.ts
+++ b/packages/cdk-blue-green-container-deployment/src/ecs-service.ts
@@ -25,6 +25,7 @@ export interface EcsServiceProps {
   readonly prodTargetGroup: ITargetGroup;
   readonly testTargetGroup: ITargetGroup;
   readonly taskDefinition: DummyTaskDefinition;
+  readonly enableExecuteCommand?: boolean;
 
   /**
    * The period of time, in seconds, that the Amazon ECS service scheduler ignores unhealthy
@@ -85,6 +86,7 @@ export class EcsService extends Construct implements IConnectable, IEcsService, 
       testTargetGroup,
       taskDefinition,
       healthCheckGracePeriod = Duration.seconds(60),
+      enableExecuteCommand,
     } = props;
 
     this.tags = new TagManager(TagType.KEY_VALUE, 'TagManager');
@@ -142,6 +144,7 @@ export class EcsService extends Construct implements IConnectable, IEcsService, 
         ContainerPort: containerPort,
         SchedulingStrategy: SchedulingStrategy.REPLICA,
         HealthCheckGracePeriodSeconds: healthCheckGracePeriod.toSeconds(),
+        EnableExecuteCommand: enableExecuteCommand,
         PropagateTags: props.propagateTags,
         DeploymentConfiguration: {
           maximumPercent: props.maxHealthyPercent ?? 200,

--- a/packages/cdk-blue-green-container-deployment/src/lambdas/ecs-service/index.ts
+++ b/packages/cdk-blue-green-container-deployment/src/lambdas/ecs-service/index.ts
@@ -31,6 +31,7 @@ export interface BlueGreenServiceProps {
   deploymentConfiguration: ECS.DeploymentConfiguration;
   propagateTags: 'SERVICE' | 'TASK_DEFINITION' | string;
   tags: Tag[];
+  enableExecuteCommand?: boolean;
 }
 
 const ecs = new ECS();
@@ -52,6 +53,7 @@ const getProperties = (props: CloudFormationCustomResourceEvent['ResourcePropert
   deploymentConfiguration: props.DeploymentConfiguration,
   propagateTags: props.PropagateTags,
   tags: props.Tags ?? [],
+  enableExecuteCommand: props.enableExecuteCommand,
 });
 
 export const handleCreate: OnCreateHandler = async (event): Promise<ResourceHandlerReturn> => {
@@ -72,6 +74,7 @@ export const handleCreate: OnCreateHandler = async (event): Promise<ResourceHand
     deploymentConfiguration,
     propagateTags,
     tags,
+    enableExecuteCommand,
   } = getProperties(event.ResourceProperties);
 
   const { service } = await ecs
@@ -105,6 +108,7 @@ export const handleCreate: OnCreateHandler = async (event): Promise<ResourceHand
       tags: tags.map((t) => {
         return { key: t.Key, value: t.Value };
       }),
+      enableExecuteCommand
     })
     .promise();
 
@@ -127,7 +131,7 @@ export const handleCreate: OnCreateHandler = async (event): Promise<ResourceHand
  * For more information, see CreateDeployment in the AWS CodeDeploy API Reference.
  */
 export const handleUpdate: OnUpdateHandler = async (event): Promise<ResourceHandlerReturn> => {
-  const { cluster, serviceName, desiredCount, deploymentConfiguration, healthCheckGracePeriodSeconds, tags } = getProperties(
+  const { cluster, serviceName, desiredCount, deploymentConfiguration, healthCheckGracePeriodSeconds, tags, enableExecuteCommand } = getProperties(
     event.ResourceProperties,
   );
 
@@ -138,6 +142,7 @@ export const handleUpdate: OnUpdateHandler = async (event): Promise<ResourceHand
       desiredCount,
       deploymentConfiguration,
       healthCheckGracePeriodSeconds,
+      enableExecuteCommand
     })
     .promise();
 


### PR DESCRIPTION
Add support for enabling [ECS Exec](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html) as outlined [here](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs-readme.html#ecs-exec-command)