### PR TITLE
Fixes for cdk-cloudfront-authorization

### DIFF
--- a/packages/cdk-cloudfront-authorization/src/__tests__/__snapshots__/authorizations.test.ts.snap
+++ b/packages/cdk-cloudfront-authorization/src/__tests__/__snapshots__/authorizations.test.ts.snap
@@ -340,7 +340,8 @@ Object {
               Object {
                 "Ref": "SpaAuthorizationSecretGeneratorCustomResource7B87C244",
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -419,7 +420,8 @@ Object {
               Object {
                 "Ref": "SpaAuthorizationSecretGeneratorCustomResource7B87C244",
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -498,7 +500,8 @@ Object {
               Object {
                 "Ref": "SpaAuthorizationSecretGeneratorCustomResource7B87C244",
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -577,7 +580,8 @@ Object {
               Object {
                 "Ref": "SpaAuthorizationSecretGeneratorCustomResource7B87C244",
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -1325,7 +1329,8 @@ Object {
                   "UserPoolClient.ClientSecret",
                 ],
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -1412,7 +1417,8 @@ Object {
                   "UserPoolClient.ClientSecret",
                 ],
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -1499,7 +1505,8 @@ Object {
                   "UserPoolClient.ClientSecret",
                 ],
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -1586,7 +1593,8 @@ Object {
                   "UserPoolClient.ClientSecret",
                 ],
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],

--- a/packages/cdk-cloudfront-authorization/src/__tests__/__snapshots__/distributions.test.ts.snap
+++ b/packages/cdk-cloudfront-authorization/src/__tests__/__snapshots__/distributions.test.ts.snap
@@ -393,7 +393,8 @@ Object {
               Object {
                 "Ref": "SpaAuthorizationSecretGeneratorCustomResource7B87C244",
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -472,7 +473,8 @@ Object {
               Object {
                 "Ref": "SpaAuthorizationSecretGeneratorCustomResource7B87C244",
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -551,7 +553,8 @@ Object {
               Object {
                 "Ref": "SpaAuthorizationSecretGeneratorCustomResource7B87C244",
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -630,7 +633,8 @@ Object {
               Object {
                 "Ref": "SpaAuthorizationSecretGeneratorCustomResource7B87C244",
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -1788,7 +1792,8 @@ Object {
                   "UserPoolClient.ClientSecret",
                 ],
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -1875,7 +1880,8 @@ Object {
                   "UserPoolClient.ClientSecret",
                 ],
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -1962,7 +1968,8 @@ Object {
                   "UserPoolClient.ClientSecret",
                 ],
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],
@@ -2049,7 +2056,8 @@ Object {
                   "UserPoolClient.ClientSecret",
                 ],
               },
-              "\\"
+              "\\",
+  \\"httpHeaders\\": []
 }",
             ],
           ],

--- a/packages/cdk-cloudfront-authorization/src/auth-flow.ts
+++ b/packages/cdk-cloudfront-authorization/src/auth-flow.ts
@@ -19,6 +19,7 @@ export interface AuthFlowProps {
   readonly cookieSettings: Record<string, string>;
   readonly nonceSigningSecret: string;
   readonly clientSecret?: string;
+  readonly httpHeaders?: Record<string, string>;
 }
 
 export class AuthFlow extends Construct {
@@ -44,6 +45,7 @@ export class AuthFlow extends Construct {
       cookieSettings: props.cookieSettings,
       nonceSigningSecret: props.nonceSigningSecret,
       clientSecret: props.clientSecret,
+      httpHeaders: props.httpHeaders ?? [],
     };
 
     this.checkAuth = new EdgeFunction(this, 'CheckAuth', {

--- a/packages/cdk-cloudfront-authorization/src/authorizations.ts
+++ b/packages/cdk-cloudfront-authorization/src/authorizations.ts
@@ -44,6 +44,7 @@ export interface AuthorizationProps {
   readonly oauthScopes?: aws_cognito.OAuthScope[];
   readonly cookieSettings?: Record<string, string>;
   readonly identityProviders?: aws_cognito.UserPoolClientIdentityProvider[];
+  readonly httpHeaders?: Record<string, string> | undefined;
 }
 
 export abstract class Authorization extends Construct {
@@ -59,6 +60,7 @@ export abstract class Authorization extends Construct {
   protected readonly cognitoAuthDomain: string;
   protected readonly identityProviders: aws_cognito.UserPoolClientIdentityProvider[];
   protected readonly responseHeaderPolicy: aws_cloudfront.IResponseHeadersPolicy;
+  protected readonly httpHeaders: Record<string, string> | undefined;
 
   constructor(scope: Construct, id: string, props: AuthorizationProps) {
     super(scope, id);
@@ -125,6 +127,8 @@ export abstract class Authorization extends Construct {
     this.nonceSigningSecret = this.generateNonceSigningSecret();
 
     this.cognitoAuthDomain = this.retrieveCognitoAuthDomain();
+
+    this.httpHeaders = props.httpHeaders;
 
     this.authFlow = this.createAuthFlow(props.logLevel ?? LogLevel.WARN);
   }
@@ -297,6 +301,7 @@ export class StaticSiteAuthorization extends Authorization implements IStaticSit
         refreshToken: 'Path=/; Secure; HttpOnly; SameSite=Lax',
         nonce: 'Path=/; Secure; HttpOnly; SameSite=Lax',
       },
+      httpHeaders: this.httpHeaders,
     });
   }
 

--- a/packages/cdk-cloudfront-authorization/src/lambdas/user-pool-domain/index.ts
+++ b/packages/cdk-cloudfront-authorization/src/lambdas/user-pool-domain/index.ts
@@ -7,8 +7,9 @@ import type {
 } from 'aws-lambda';
 import axios from 'axios';
 
+const awsRegion = process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION;
 const COGNITO_CLIENT = new CognitoIdentityProvider({
-  region: process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION,
+  region: awsRegion,
 });
 
 async function ensureCognitoUserPoolDomain(userPoolId: string): Promise<string> {
@@ -28,7 +29,7 @@ async function ensureCognitoUserPoolDomain(userPoolId: string): Promise<string> 
     throw new Error('Cognito auth domain is missing! Either a domain prefix or a custom domain must be configured.');
   }
 
-  return userPool.CustomDomain ?? `${userPool.Domain}.auth.${COGNITO_CLIENT.config.region}.amazoncognito.com`;
+  return userPool.CustomDomain ?? `${userPool.Domain}.auth.${awsRegion}.amazoncognito.com`;
 }
 
 export const handler: CloudFormationCustomResourceHandler = async (event) => {


### PR DESCRIPTION
* Adjusted user-pool-domain lambda to use region directly instead of from the cognito client resolved config (Fix for #211)
* Updated Authorizations and AuthFlow to add a sane default for httpHeaders (which was causing the edge functions to error and fail (including the example code), and updated test snapshots for the same - fixes #171 
* Updated the cdk-lambda-at-edge-pattern WithConfiguration construct lambda function to wait for the Lambda function status to go Active and then wait for propagation, which was causing distribution deployments (including the example) to fail

Build results:
```
 Lerna (powered by Nx)   Successfully ran target build for 45 projects (2m)
```

Test results:
```
Test Suites: 42 passed, 42 total
Tests:       106 passed, 106 total
Snapshots:   64 passed, 64 total
Time:        5.705 s
Ran all test suites in 27 projects.
```

*Note: I didn't see any tests for the lambda functions, but I've tested this in my own envionment