### PR TITLE
Avoid redundant domain name entry

### DIFF
--- a/packages/cdk-static-website/src/static-website.ts
+++ b/packages/cdk-static-website/src/static-website.ts
@@ -367,7 +367,7 @@ export class StaticWebsite extends Construct {
 
     return new aws_certificatemanager.DnsValidatedCertificate(this, 'Certificate', {
       domainName: domainNames[0],
-      subjectAlternativeNames: domainNames,
+      subjectAlternativeNames: domainNames.slice(1),
       hostedZone,
       region: 'us-east-1',
     });


### PR DESCRIPTION
Previously, the first domain name was passed to the `DnsValidatedCertificate` construct twice.

In the `domainName` prop and again in the `subjectAlternativeNames`.

For example, when using `new StaticWebsite(app, "Website", { domainNames: ["example.org"], … })`, the wildcard domain `*.example.org` was specified twice.

For reference, see [the corresponding code in `DnsValidatedCertificate`](https://github.com/aws/aws-cdk/blob/v2.153.0/packages/aws-cdk-lib/aws-certificatemanager/lib/dns-validated-certificate.ts#L134-L139).

There is one thing I was not able to verify yet. The value of `subjectAlternativeNames` is used in one more place in the `DnsValidatedCertificate` construct:
https://github.com/aws/aws-cdk/blob/v2.153.0/packages/aws-cdk-lib/aws-certificatemanager/lib/dns-validated-certificate.ts#L147

The custom resource also receives `domainName` separately, but I couldn't tell whether removing it from the `subjectAlternativeNames` might have any side effects here.

Kind regards,
Paul